### PR TITLE
Fix orientation bug in optimization trajectory workflow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ import setuptools
 
 # Package meta-data.
 NAME = "smlb"
-VERSION = "0.1.0"
+VERSION = "0.1.1"
 DESCRIPTION = "Scientific Machine Learning Benchmark"
 URL = "https://github.com/CitrineInformatics/smlb"
 EMAIL = "mrupp@mrupp.io"

--- a/smlb/core/optimizer.py
+++ b/smlb/core/optimizer.py
@@ -147,9 +147,9 @@ class TrackedTransformation(DataTransformation):
         self._learner = params.instance(learner, Learner)
         self._scorer = params.instance(scorer, Scorer)
 
-        maximize = params.boolean(maximize)
+        self._maximize = params.boolean(maximize)
         # If the goal is to maximize the score, invert the value because optimizers minimize.
-        if maximize:
+        if self.maximize:
             self._direction = -1
         else:
             self._direction = 1
@@ -166,6 +166,12 @@ class TrackedTransformation(DataTransformation):
         """Sequence of what happened at each step of the optimizer."""
 
         return self._steps
+
+    @property
+    def maximize(self) -> bool:
+        """Whether to maximize or minimize the score."""
+
+        return self._maximize
 
     @property
     def direction(self) -> float:

--- a/smlb/workflows/optimization_trajectory_comparison.py
+++ b/smlb/workflows/optimization_trajectory_comparison.py
@@ -95,10 +95,9 @@ class OptimizationTrajectoryComparison(Workflow):
                 of all the scores at that point (vertical axis).
             """
             max_trajectory_length = np.max([t.num_evaluations for t in list_of_trajectories])
-            maximize = func.direction == 1.0
             best_score_trajectories = np.vstack(
                 [
-                    t.best_score_trajectory(maximize, max_trajectory_length)
+                    t.best_score_trajectory(func.maximize, max_trajectory_length)
                     for t in list_of_trajectories
                 ]
             )


### PR DESCRIPTION
If we're trying to maximize a quantity then the "orientation" is -1 because optimizers minimize. The analysis code was asking for the orientation when it should have been explicitly asking "are we trying to maximize this score?"