### PR TITLE
Support string and number column names

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ import setuptools
 
 # Package meta-data.
 NAME = "smlb"
-VERSION = "0.3.2"
+VERSION = "0.3.3"
 DESCRIPTION = "Scientific Machine Learning Benchmark"
 URL = "https://github.com/CitrineInformatics/smlb"
 EMAIL = "mrupp@mrupp.io"

--- a/smlb/core/tabular_data.py
+++ b/smlb/core/tabular_data.py
@@ -501,14 +501,14 @@ class TabularDataFromPandas(TabularData):
         if isinstance(labels, pd.DataFrame):
             if len(data) != len(labels):
                 raise InvalidParameterError(
-                    "matching data and labelsa",
+                    "matching data and labels",
                     f"different number of rows ({len(data)} != {len(labels)})",
                 )
 
             labels = labels.reset_index(drop=True)
 
-            col_names = np.hstack((data.columns.values, labels.columns.values))
-            if len(col_names) != len(np.unique(col_names)):
+            col_names = np.hstack((data.columns, labels.columns))
+            if len(col_names) != len(pd.unique(col_names)):
                 raise InvalidParameterError(
                     "unique column names", f"{data.columns.values} and {labels.columns.values}"
                 )

--- a/tests/core/test_tabular_data.py
+++ b/tests/core/test_tabular_data.py
@@ -779,3 +779,13 @@ def test_TabularDataFromPandas_initialization():
     )
     assert (ds.samples() == samples).all()
     assert (ds.labels() == labels).all()
+
+def test_TabularDataFromPandas_string_column_uniqueness():
+    data_samples = pd.DataFrame({1:[1,2,3], 2:[4,5,6], 3:[7,8,9], 'id':[1,2,3]})
+    labels_samples = pd.DataFrame({'id':[1.5,2.5,3.5]})
+
+    col_names = np.hstack((data_samples.columns, labels_samples.columns))
+    assert len(col_names) > len(pd.unique(col_names))
+
+    with pytest.raises(smlb.InvalidParameterError):
+        tdfp = smlb.TabularDataFromPandas(data=data_samples, labels=labels_samples)

--- a/tests/core/test_tabular_data.py
+++ b/tests/core/test_tabular_data.py
@@ -780,12 +780,18 @@ def test_TabularDataFromPandas_initialization():
     assert (ds.samples() == samples).all()
     assert (ds.labels() == labels).all()
 
+
 def test_TabularDataFromPandas_string_column_uniqueness():
     data_samples = pd.DataFrame({1:[1,2,3], 2:[4,5,6], 3:[7,8,9], 'id':[1,2,3]})
     labels_samples = pd.DataFrame({'id':[1.5,2.5,3.5]})
 
-    col_names = np.hstack((data_samples.columns, labels_samples.columns))
-    assert len(col_names) > len(pd.unique(col_names))
+    with pytest.raises(smlb.InvalidParameterError):
+        tdfp = smlb.TabularDataFromPandas(data=data_samples, labels=labels_samples)
+
+
+def test_TabularDataFromPandas_fails_different_lengths():
+    data_samples = pd.DataFrame({'a':[1,2,3,4], 'b':[4,5,6,7], 'c':[7,8,9,10], 'id':[1,2,3,4]}) # 4 elements
+    labels_samples = pd.DataFrame({'id2':[1.5,2.5]}) # 2 elements
 
     with pytest.raises(smlb.InvalidParameterError):
         tdfp = smlb.TabularDataFromPandas(data=data_samples, labels=labels_samples)


### PR DESCRIPTION
A small fix to allow mixed columns names, meaning I can have integer column names or strings, or both. Before, this errored out on a comparison of string and int column names in the `np.unique` call on inputs like
```
data = pd.DataFrame({1:[1,2,3], 2:[4,5,6], 3:[7,8,9], 'id':[1,2,3]})
labels = pd.DataFrame({'id':[1,2,3]})
```

```
TypeError: '<' not supported between instances of 'str' and 'int'
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-38-a990f5dd8a1d> in <module>
      3 
      4 col_names = np.hstack((data.columns, labels.columns))
----> 5 len(col_names) > len(np.unique(col_names))

<__array_function__ internals> in unique(*args, **kwargs)

~/miniconda3/envs/smlb/lib/python3.7/site-packages/numpy/lib/arraysetops.py in unique(ar, return_index, return_inverse, return_counts, axis)
    260     ar = np.asanyarray(ar)
    261     if axis is None:
--> 262         ret = _unique1d(ar, return_index, return_inverse, return_counts)
    263         return _unpack_tuple(ret)
    264 

~/miniconda3/envs/smlb/lib/python3.7/site-packages/numpy/lib/arraysetops.py in _unique1d(ar, return_index, return_inverse, return_counts)
    321         aux = ar[perm]
    322     else:
--> 323         ar.sort()
    324         aux = ar
    325     mask = np.empty(aux.shape, dtype=np.bool_)

TypeError: '<' not supported between instances of 'str' and 'int'
```

Tests passed locally.

I was also going to see if I could add support for pd.Series `labels`, but there is some code that plays with the column names. Series don't have column names, so that would be a bigger fix if it is necessary.