### PR TITLE
Store results in auxiliary data.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ import setuptools
 
 # Package meta-data.
 NAME = "smlb"
-VERSION = "0.3.4"
+VERSION = "0.3.5"
 DESCRIPTION = "Scientific Machine Learning Benchmark"
 URL = "https://github.com/CitrineInformatics/smlb"
 EMAIL = "mrupp@mrupp.io"

--- a/smlb/core/plots.py
+++ b/smlb/core/plots.py
@@ -822,6 +822,8 @@ class LearningCurvePlot(GeneralizedFunctionPlot):
         curve_testf = lambda arg: params.tuple_(arg, tuple_testf)
         results = params.tuple_(results, curve_testf)
 
+        self.add_auxiliary("results", results)
+
         super().evaluate(results=results, **kwargs)
 
         ypowf = self._powf if self.axes_scales[1] == "log" else lambda arg: arg


### PR DESCRIPTION
This PR adds the raw `results` given to a `LearningCurvePlot` to the evaluation's  auxiliary data. (This way we can easily reference the data passed to the evaluation after the fact.)