### PR TITLE
Added pipeline transformation.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ import setuptools
 
 # Package meta-data.
 NAME = "smlb"
-VERSION = "0.4.0"
+VERSION = "0.5.0"
 DESCRIPTION = "Scientific Machine Learning Benchmark"
 URL = "https://github.com/CitrineInformatics/smlb"
 EMAIL = "mrupp@mrupp.io"

--- a/smlb/__init__.py
+++ b/smlb/__init__.py
@@ -17,11 +17,12 @@ from smlb.core.vector_space_data import VectorSpaceData
 from smlb.core.transformations import (
     DataTransformation,
     DataValuedTransformation,
+    DataPipelineTransformation,
     IdentityTransformation,
     InvertibleTransformation,
     DataTransformationFailureMode,
 )
-from smlb.core.features import Features, IdentityFeatures
+from smlb.core.features import Features, IdentityFeatures, DataPipelineFeatures
 from smlb.core.sampling import Sampler, RandomSubsetSampler, RandomVectorSampler, GridSampler
 from smlb.core.distributions import (
     PredictiveDistribution,

--- a/smlb/core/features.py
+++ b/smlb/core/features.py
@@ -8,7 +8,7 @@ Features transform datasets.
 """
 
 
-from smlb import DataValuedTransformation, IdentityTransformation
+from smlb import DataValuedTransformation, IdentityTransformation, DataPipelineTransformation
 
 
 class Features(DataValuedTransformation):
@@ -21,5 +21,11 @@ class Features(DataValuedTransformation):
 
 class IdentityFeatures(Features, IdentityTransformation):
     """Leaves dataset unchanged."""
+
+    pass
+
+
+class DataPipelineFeatures(Features, DataPipelineTransformation):
+    """Applies transformation steps sequentially."""
 
     pass

--- a/smlb/core/transformations.py
+++ b/smlb/core/transformations.py
@@ -103,7 +103,6 @@ class DataPipelineTransformation(DataValuedTransformation):
 
         Parameters:
             steps: List of data-valued transformations
-
         """
         super().__init__(*args, **kwargs)
         steps = params.sequence(steps, type_=DataValuedTransformation)

--- a/smlb/core/transformations.py
+++ b/smlb/core/transformations.py
@@ -23,15 +23,15 @@ Design decisions:
 """
 
 from abc import ABCMeta, abstractmethod
-from typing import Any
+from typing import Any, Sequence
 
 import numpy as np
 
-from smlb import Data, complement
 from smlb import BenchmarkError, InvalidParameterError
+from smlb import Data, complement
 from smlb import SmlbObject
-from smlb import params
 from smlb import is_sequence
+from smlb import params
 
 
 class DataTransformation(SmlbObject, metaclass=ABCMeta):
@@ -95,6 +95,52 @@ class DataValuedTransformation(DataTransformation):
         raise NotImplementedError
 
 
+class DataPipelineTransformation(DataValuedTransformation):
+    """Pipeline of data-valued transformations that are applied sequentially."""
+
+    def __init__(self, steps: Sequence[DataValuedTransformation], *args, **kwargs):
+        """Initialize state.
+
+        Parameters:
+            steps: List of data-valued transformations
+
+        """
+        super().__init__(*args, **kwargs)
+        steps = params.sequence(steps, type_=DataValuedTransformation)
+        self._steps = steps
+
+    def fit(self, data: Data) -> "DataPipelineTransformation":
+        """Fit each step.
+
+        Steps are fit sequentially and used to transform the data.
+        The transformed output of each step is used as the training data for the next step.
+
+        Parameters:
+            data: training data
+
+        Returns:
+            self, to allow chaining
+        """
+        for step in self._steps:
+            data = step.fit(data).apply(data)
+        return self
+
+    def apply(self, data: Data) -> Data:
+        """Apply each step sequentially.
+
+        The transformed output of each step is used as the training data for the next step.
+
+        Parameters:
+            data: data to transform
+
+        Returns:
+            transformed data
+        """
+        for step in self._steps:
+            data = step.apply(data)
+        return data
+
+
 class IdentityTransformation(DataValuedTransformation):
     """Returns data unchanged."""
 
@@ -149,7 +195,7 @@ class DataTransformationFailureMode:
         Parameters:
             failmode: how to handle failed descriptor calculations, either due to rejected SMILES
                 encodings or failing descriptor code. Possible values:
-                "raise" [default]: raise a Benchmarexception
+                "raise" [default]: raise a BenchmarkException
                 "drop": drop the sample. Returned Data will have fewer samples
                 ("mask", mask): where `mask` is a NumPy array with dtype bool whose entries will
                     be set to False for failures

--- a/smlb/workflows/learning_curve_regression.py
+++ b/smlb/workflows/learning_curve_regression.py
@@ -77,7 +77,7 @@ class LearningCurveRegression(Workflow):
         training: Sequence[Sampler],
         validation: Sampler,
         learners: Sequence[SupervisedLearner],
-        features: DataValuedTransformation = IdentityFeatures(),
+        features: Features = IdentityFeatures(),
         metric: ScalarEvaluationMetric = RootMeanSquaredError(),
         evaluations: Sequence[Evaluation] = (LearningCurvePlot(),),  # todo: add table
         progressf: Optional[Callable[[int, int], None]] = None,

--- a/tests/core/test_transformations.py
+++ b/tests/core/test_transformations.py
@@ -4,11 +4,28 @@ Scientific Machine Learning Benchmark:
 A benchmark of regression models in chem- and materials informatics.
 """
 
+import numpy as np
 import pytest
 
-import numpy as np
-
 import smlb
+from smlb.decomposition import PCASklearn
+
+
+################################
+#  DataPipelineTransformation  #
+################################
+
+
+def test_DataPipelineTransformation(friedman_1979_data):
+    n_rows = friedman_1979_data.num_samples
+    n_components = 3
+    pca = PCASklearn(rng=0, n_components=n_components)
+    identity = smlb.IdentityTransformation()
+    pipeline = smlb.DataPipelineTransformation(steps=(pca, identity))
+    pipeline.fit(friedman_1979_data)
+    transformed = pipeline.apply(friedman_1979_data)
+    assert transformed.samples().shape == (n_rows, n_components)
+
 
 ###########################
 #  InverseTransformation  #


### PR DESCRIPTION
This PR adds a data pipeline transformation that applies transformation steps sequentially. This allows you to perform, for example, featurization in combination with a feature selection strategy. The idea is based off sklearn's [`Pipeline`](https://scikit-learn.org/stable/modules/generated/sklearn.pipeline.Pipeline.html).