### PR TITLE
Added base class for sklearn feature selection methods.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- '3.7'
 - '3.8'
 - '3.9'
 cache:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,7 +25,7 @@ To run the interactive notebooks provided with `smlb`, such as the tutorial, ins
 Creating a virtual environment helps in developing and testing with different versions of packages. A popular tool is [Anaconda](https://www.anaconda.com/); for this, run below before installing `smlb`:
 
 ```
-conda create --name <environment name> python=3.7 numpy scipy pandas jupyterlab scikit-learn
+conda create --name <environment name> python=3.8 numpy scipy pandas jupyterlab scikit-learn
 conda install -c conda-forge matplotlib
 conda activate <environment name>
 ```

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ EMAIL = "mrupp@mrupp.io"
 AUTHOR = "Matthias Rupp"
 LICENSE = "Apache-2.0"  # SPDX short identifier
 LICENSE_TROVE = "License :: OSI Approved :: Apache Software License"  # https://pypi.python.org/pypi?%3Aaction=list_classifiers
-REQUIRES_PYTHON = ">=3.7.0"
+REQUIRES_PYTHON = ">=3.8.0"
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -79,7 +79,6 @@ setuptools.setup(
         LICENSE_TROVE,
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ import setuptools
 
 # Package meta-data.
 NAME = "smlb"
-VERSION = "0.8.0"
+VERSION = "0.8.1"
 DESCRIPTION = "Scientific Machine Learning Benchmark"
 URL = "https://github.com/CitrineInformatics/smlb"
 EMAIL = "mrupp@mrupp.io"

--- a/smlb/feature_selection/feature_selector_sklearn.py
+++ b/smlb/feature_selection/feature_selector_sklearn.py
@@ -21,7 +21,9 @@ class FeatureSelectorSklearn(Features):
             selector: Feature selection method that provides ``fit`` and ``get_support`` methods.
         """
         super().__init__(*args, **kwargs)
-        self._selector: SelectorProtocolSklearn = selector
+        self._selector: SelectorProtocolSklearn = params.instance(
+            selector, SelectorProtocolSklearn
+        )
 
     def fit(self, data: Data) -> "FeatureSelectorSklearn":
         """Fit the model with input ``data``.

--- a/smlb/feature_selection/feature_selector_sklearn.py
+++ b/smlb/feature_selection/feature_selector_sklearn.py
@@ -1,0 +1,60 @@
+from smlb import (
+    params,
+    Data,
+    Features,
+    TabularData,
+)
+from smlb.feature_selection.selector_protocol_sklearn import SelectorProtocolSklearn
+
+
+class FeatureSelectorSklearn(Features):
+    """Base class for feature selection strategies that use one of scikit-learn's feature selection methods.
+
+    This class relies on a ``selector`` provided on initialization that provides ``fit`` and ``get_support`` methods
+     to select features from a dataset.
+    """
+
+    def __init__(self, selector: SelectorProtocolSklearn, *args, **kwargs):
+        """Initialize state.
+
+        Parameters:
+            selector: Feature selection method that provides ``fit`` and ``get_support`` methods.
+        """
+        super().__init__(*args, **kwargs)
+        self._selector: SelectorProtocolSklearn = selector
+
+    def fit(self, data: Data) -> "FeatureSelectorSklearn":
+        """Fit the model with input ``data``.
+
+        Parameters:
+            data: data to fit
+
+        Returns:
+            the instance itself
+        """
+        data = params.instance(data, Data)
+        n = data.num_samples
+
+        xtrain = params.real_matrix(data.samples(), nrows=n)
+        ytrain = params.real_vector(data.labels(), dimensions=n)
+
+        self._selector.fit(xtrain, ytrain)
+
+        return self
+
+    def apply(self, data: Data) -> TabularData:
+        """Select features from the data.
+
+        Parameters:
+            data: data to select features from
+
+        Returns:
+            data with selected features
+        """
+        data = params.instance(data, Data)
+        samples = params.real_matrix(data.samples())
+
+        support = self._selector.get_support()
+        selected = samples[:, support]
+
+        return TabularData(selected, data.labels())

--- a/smlb/feature_selection/select_from_model_sklearn.py
+++ b/smlb/feature_selection/select_from_model_sklearn.py
@@ -4,14 +4,12 @@ from sklearn.feature_selection import SelectFromModel
 
 from smlb import (
     params,
-    Data,
-    Features,
     SupervisedLearner,
-    TabularData,
 )
+from smlb.feature_selection.feature_selector_sklearn import FeatureSelectorSklearn
 
 
-class SelectFromModelSklearn(Features):
+class SelectFromModelSklearn(FeatureSelectorSklearn):
     """Select features based on importance weights using the scikit-learn SelectFromModel implementation.
 
     .. seealso::
@@ -70,8 +68,7 @@ class SelectFromModelSklearn(Features):
         else:
             estimator = estimator_getter(learner)
 
-        super().__init__(*args, **kwargs)
-        self._select_from_model = SelectFromModel(
+        selector = SelectFromModel(
             estimator=estimator,
             threshold=threshold,
             prefit=prefit,
@@ -80,38 +77,4 @@ class SelectFromModelSklearn(Features):
             importance_getter="auto",
         )
 
-    def fit(self, data: Data) -> "SelectFromModelSklearn":
-        """Fit the model with input ``data``.
-
-        Parameters:
-            data: data to fit
-
-        Returns:
-            the instance itself
-        """
-        data = params.instance(data, Data)
-        n = data.num_samples
-
-        xtrain = params.real_matrix(data.samples(), nrows=n)
-        ytrain = params.real_vector(data.labels(), dimensions=n)
-
-        self._select_from_model.fit(xtrain, ytrain)
-
-        return self
-
-    def apply(self, data: Data) -> TabularData:
-        """Select features from the data.
-
-        Parameters:
-            data: data to select features from
-
-        Returns:
-            data with selected features
-        """
-        data = params.instance(data, Data)
-        samples = params.real_matrix(data.samples())
-
-        support = self._select_from_model.get_support()
-        selected = samples[:, support]
-
-        return TabularData(selected, data.labels())
+        super().__init__(selector=selector, *args, **kwargs)

--- a/smlb/feature_selection/select_percentile_sklearn.py
+++ b/smlb/feature_selection/select_percentile_sklearn.py
@@ -2,15 +2,11 @@ from typing import Callable
 
 from sklearn.feature_selection import SelectPercentile
 
-from smlb import (
-    params,
-    Data,
-    Features,
-    TabularData,
-)
+from smlb import params
+from smlb.feature_selection.feature_selector_sklearn import FeatureSelectorSklearn
 
 
-class SelectPercentileSklearn(Features):
+class SelectPercentileSklearn(FeatureSelectorSklearn):
     """Select features based on percentile of highest scores, scikit-learn implementation.
 
     .. seealso::
@@ -26,42 +22,5 @@ class SelectPercentileSklearn(Features):
         """
         score_func = params.callable(score_func, num_pos_or_kw=2)
         percentile = params.integer(percentile, from_=0, to=100)
-
-        super().__init__(*args, **kwargs)
-        self._select_percentile = SelectPercentile(score_func=score_func, percentile=percentile)
-
-    def fit(self, data: Data) -> "SelectPercentileSklearn":
-        """Fit the model with input ``data``.
-
-        Parameters:
-            data: data to fit
-
-        Returns:
-            the instance itself
-        """
-        data = params.instance(data, Data)
-        n = data.num_samples
-
-        xtrain = params.real_matrix(data.samples(), nrows=n)
-        ytrain = params.real_vector(data.labels(), dimensions=n)
-
-        self._select_percentile.fit(xtrain, ytrain)
-
-        return self
-
-    def apply(self, data: Data) -> TabularData:
-        """Select features from the data.
-
-        Parameters:
-            data: data to select features from
-
-        Returns:
-            data with selected features
-        """
-        data = params.instance(data, Data)
-        samples = params.real_matrix(data.samples())
-
-        support = self._select_percentile.get_support()
-        selected = samples[:, support]
-
-        return TabularData(selected, data.labels())
+        selector = SelectPercentile(score_func=score_func, percentile=percentile)
+        super().__init__(selector=selector, *args, **kwargs)

--- a/smlb/feature_selection/selector_protocol_sklearn.py
+++ b/smlb/feature_selection/selector_protocol_sklearn.py
@@ -1,0 +1,41 @@
+from abc import abstractmethod
+from typing import Protocol
+
+import numpy as np
+from numpy import typing as npt
+
+
+class SelectorProtocolSklearn(Protocol):
+    """Protocol that defines the methods expected from a scikit-learn feature selector."""
+
+    @abstractmethod
+    def fit(self, X: npt.ArrayLike, y: npt.ArrayLike) -> "SelectorProtocolSklearn":
+        """Fit the underlying estimator to the given data.
+
+        Parameters:
+            X: training data of shape ``(n_samples, n_features)``
+            y: target values of shape ``(n_samples,)`` or ``(n_samples, n_targets)``
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_support(self, indices: bool = False) -> np.array:
+        """
+        Get a mask, or integer index, of the features selected.
+
+        Parameters
+        ----------
+        indices : If True, the return value will be an array of integers, rather than a boolean mask.
+            Default is False.
+
+        Returns
+        -------
+        support : array
+            An index that selects the retained features from a feature vector.
+            If ``indices`` is False, this is a boolean array of shape
+            [# input features], in which an element is True iff its
+            corresponding feature is selected for retention.
+            If ``indices`` is True, this is an integer array of shape
+            [# output features] whose values are indices into the input feature vector.
+        """
+        raise NotImplementedError

--- a/smlb/feature_selection/selector_protocol_sklearn.py
+++ b/smlb/feature_selection/selector_protocol_sklearn.py
@@ -1,10 +1,11 @@
 from abc import abstractmethod
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 import numpy as np
 from numpy import typing as npt
 
 
+@runtime_checkable
 class SelectorProtocolSklearn(Protocol):
     """Protocol that defines the methods expected from a scikit-learn feature selector."""
 


### PR DESCRIPTION
Adding sklearn feature selection strategies is a bit repetitive. The `fit` and `apply` logic is nearly identical between strategies. The only difference is the name of the member used to select features. In this PR I added a base class `FeatureSelectorSklearn` that defines common `fit` and `apply` methods. It relies on a `selector` that conforms to `SelectorProtocolSklearn` (a protocol also defined in this PR since sklearns selector mixin doesn't require a `fit` method) to select features. I refactored the existing sklearn feature selection methods to use the new base class. There's not really any new logic here (unless you count formalizing the methods required from a selector).

Protocols were introduced Python 3.8, so this version drops support for Python 3.7.