### PR TITLE
Allow None for n_features_to_select.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ import setuptools
 
 # Package meta-data.
 NAME = "smlb"
-VERSION = "0.9.0"
+VERSION = "0.9.1"
 DESCRIPTION = "Scientific Machine Learning Benchmark"
 URL = "https://github.com/CitrineInformatics/smlb"
 EMAIL = "mrupp@mrupp.io"

--- a/smlb/feature_selection/rfe_sklearn.py
+++ b/smlb/feature_selection/rfe_sklearn.py
@@ -48,18 +48,17 @@ class RFESklearn(FeatureSelectorSklearn):
 
         learner = params.instance(learner, SupervisedLearner)
 
-        is_nneg_int = lambda x: params.integer(x, from_=0)
-
         # We need to differentiate between int and float here because params
-        # will cast the argument to an int when it tests is_nneg_int.
-        # If you give it a float on the range (0.0, 1.0), you'll be left with
-        # n_features == 0 after the conversion instead of the expected fraction of features.
+        # will cast the argument to an int when it tests the parameter.
+        # 1 is a valid int and float but has a different meaning based on type.
+        # If it's an int, it means select 1 feature.
+        # If it's a float, it means select all features.
         if n_features_to_select is None:
             pass  # None is allowed, no need for further type checking
         elif isinstance(n_features_to_select, int):
-            n_features_to_select = is_nneg_int(n_features_to_select)
+            n_features_to_select = params.integer(n_features_to_select, from_=1)
         elif isinstance(n_features_to_select, float):
-            n_features_to_select = params.real(n_features_to_select, above=0, to=1.0)
+            n_features_to_select = params.real(n_features_to_select, above=0.0, to=1.0)
         else:
             raise InvalidParameterError("optional integer or float", n_features_to_select)
 
@@ -67,7 +66,7 @@ class RFESklearn(FeatureSelectorSklearn):
         is_valid_step_real = lambda x: params.real(x, above=0.0, below=1.0)
         step = params.any_(step, is_valid_step_int, is_valid_step_real)
 
-        verbose = is_nneg_int(verbose)
+        verbose = params.integer(verbose, from_=0)
 
         is_callable = lambda arg: params.callable(arg, num_pos_or_kw=1)
         estimator_getter = params.any_(estimator_getter, params.string, is_callable)

--- a/smlb/feature_selection/rfe_sklearn.py
+++ b/smlb/feature_selection/rfe_sklearn.py
@@ -54,13 +54,14 @@ class RFESklearn(FeatureSelectorSklearn):
         # will cast the argument to an int when it tests is_nneg_int.
         # If you give it a float on the range (0.0, 1.0), you'll be left with
         # n_features == 0 after the conversion instead of the expected fraction of features.
-        if isinstance(n_features_to_select, int):
-            n_features_to_select = params.optional_(n_features_to_select, is_nneg_int)
+        if n_features_to_select is None:
+            pass  # None is allowed, no need for further type checking
+        elif isinstance(n_features_to_select, int):
+            n_features_to_select = is_nneg_int(n_features_to_select)
         elif isinstance(n_features_to_select, float):
-            is_valid_n_features_real = lambda x: params.real(x, above=0, to=1.0)
-            n_features_to_select = params.optional_(n_features_to_select, is_valid_n_features_real)
+            n_features_to_select = params.real(n_features_to_select, above=0, to=1.0)
         else:
-            raise InvalidParameterError("integer or float", n_features_to_select)
+            raise InvalidParameterError("optional integer or float", n_features_to_select)
 
         is_valid_step_int = lambda x: params.integer(x, from_=1)
         is_valid_step_real = lambda x: params.real(x, above=0.0, below=1.0)

--- a/tests/feature_selection/test_rfe_sklearn.py
+++ b/tests/feature_selection/test_rfe_sklearn.py
@@ -3,19 +3,14 @@ from smlb.feature_selection import RFESklearn
 from smlb.learners import RandomForestRegressionSklearn
 
 
-def test_transform_default_getter(friedman_1979_data: Data):
+def test_transform_default_init(friedman_1979_data: Data):
     learner = RandomForestRegressionSklearn(rng=0)
-    n_features_to_select = 4
-    step = 2  # remove 2 features at a time
 
-    select_from_model = RFESklearn(
-        learner=learner,
-        n_features_to_select=n_features_to_select,
-        step=step
-    )
+    select_from_model = RFESklearn(learner=learner)
     select_from_model.fit(friedman_1979_data)
     selected = select_from_model.apply(friedman_1979_data)
-    assert selected.samples().shape == (friedman_1979_data.num_samples, n_features_to_select)
+    # by default rfe will select total # of features // 2 (== 2 for friedman data)
+    assert selected.samples().shape == (friedman_1979_data.num_samples, 2)
 
 
 def test_transform_callable_getter(friedman_1979_data: Data):


### PR DESCRIPTION
Quick follow on to #38. I forgot to check if `n_features_to_select` is `None` on init, so an invalid parameter exception would get thrown if `None` was provided. I also modified the tests to check for this oversight.