### PR TITLE
Add ability to specify backend-dependent plot options.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ import setuptools
 
 # Package meta-data.
 NAME = "smlb"
-VERSION = "0.10.0"
+VERSION = "0.11.0"
 DESCRIPTION = "Scientific Machine Learning Benchmark"
 URL = "https://github.com/CitrineInformatics/smlb"
 EMAIL = "mrupp@mrupp.io"


### PR DESCRIPTION
This PR adds a ``plot_options`` parameter to the ``PlotConfiguration``. The new parameters allows users to specify backend-dependent options when plotting.