### PR TITLE
Allow string or float for PCA n_components.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ import setuptools
 
 # Package meta-data.
 NAME = "smlb"
-VERSION = "0.10.0"
+VERSION = "0.10.1"
 DESCRIPTION = "Scientific Machine Learning Benchmark"
 URL = "https://github.com/CitrineInformatics/smlb"
 EMAIL = "mrupp@mrupp.io"

--- a/tests/decomposition/test_pca_sklearn.py
+++ b/tests/decomposition/test_pca_sklearn.py
@@ -27,13 +27,14 @@ def test_inverse_transform(friedman_1979_data: Data):
 
 
 def test_non_default_initialization():
-    svd_solver = 'randomized'
+    svd_solver = 'full'
     tol = 1.0
     iterated_power = 0
     pca = PCASklearn(
-        svd_solver='randomized',
-        tol=1.0,
-        iterated_power=0
+        n_components='mle',
+        svd_solver=svd_solver,
+        tol=tol,
+        iterated_power=iterated_power
     )
 
     assert pca._pca.svd_solver == svd_solver


### PR DESCRIPTION
This is somewhere between a feature and a bugfix. Sklearn allows n_components to be an int, float or string. Previously we only supported ints. This adds support for floats and strings.